### PR TITLE
fix: showNotification on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ No configuration required for this plugin.
 
 You can display audio playback information in the system notification center. This is perfect for music players, podcast apps, and any app that plays audio in the background.
 
+> **⚠️ Important iOS Behavior**
+> 
+> Enabling `showNotification: true` changes how your app's audio interacts with other apps on iOS:
+> 
+> - **With notifications enabled** (showNotification: true): Your audio will **interrupt** other apps' audio (like Spotify, Apple Music, etc.). This is required for Now Playing controls to appear in Control Center and on the lock screen.
+> - **With notifications disabled** (showNotification: false): Your audio will **mix** with other apps' audio, allowing background music to continue playing.
+> 
+> **When to use each:**
+> - ✅ Use `showNotification: true` for: Music players, podcast apps, audiobook players (primary audio source)
+> - ❌ Use `showNotification: false` for: Sound effects, notification sounds, secondary audio where mixing is preferred
+> 
+> See [Issue #202](https://github.com/Cap-go/capacitor-native-audio/issues/202) for technical details.
+
 **Step 1: Configure the plugin with notification support**
 
 ```typescript
@@ -193,6 +206,7 @@ The media control buttons automatically handle:
 - All metadata fields are optional
 - Artwork can be a local file path or remote URL
 - The notification only appears when `showNotification: true` is set in configure()
+- ⚠️ **iOS:** Enabling notifications will interrupt other apps' audio (see warning above)
 - iOS: Uses MPNowPlayingInfoCenter with MPRemoteCommandCenter
 - Android: Uses MediaSession with NotificationCompat.MediaStyle
 

--- a/ios/Sources/NativeAudioPlugin/Plugin.swift
+++ b/ios/Sources/NativeAudioPlugin/Plugin.swift
@@ -256,7 +256,15 @@ public class NativeAudio: CAPPlugin, AVAudioPlayerDelegate, CAPBridgedPlugin {
             // Set category first
             // Fix for issue #202: When showNotification is enabled, use .playback without
             // .mixWithOthers or .duckOthers to allow Now Playing info to display in
-            // Control Center and lock screen
+            // Control Center and lock screen.
+            //
+            // IMPORTANT: This is a behavior trade-off:
+            // - With .playback + .default mode: Now Playing info shows, but interrupts other audio
+            // - With .mixWithOthers or .duckOthers: Audio mixes, but no Now Playing info
+            //
+            // This is required because iOS only shows Now Playing controls for audio sessions
+            // that use the .playback category without mixing options. This means the app becomes
+            // the primary audio source and will interrupt background music from other apps.
             if self.showNotification {
                 // Use playback category with default mode for notification support
                 try self.session.setCategory(AVAudioSession.Category.playback, mode: .default)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -72,10 +72,35 @@ export interface ConfigureOptions {
   /**
    * Show audio playback in the notification center (iOS and Android)
    * When enabled, displays audio metadata (title, artist, album, artwork) in the system notification
+   * and Control Center (iOS) or lock screen.
+   * 
+   * **Important iOS Behavior:**
+   * Enabling this option changes the audio session category to `.playback` with `.default` mode,
+   * which means your app's audio will **interrupt** other apps' audio (like background music from
+   * Spotify, Apple Music, etc.) instead of mixing with it. This is required for the Now Playing
+   * info to appear in Control Center and on the lock screen.
+   * 
+   * **Trade-offs:**
+   * - `showNotification: true` → Shows Now Playing controls, but interrupts other audio
+   * - `showNotification: false` → Audio mixes with other apps, but no Now Playing controls
+   * 
+   * Use this when your app is the primary audio source (music players, podcast apps, etc.).
+   * Disable this for secondary audio like sound effects or notification sounds where mixing
+   * with background music is preferred.
+   * 
+   * @see https://github.com/Cap-go/capacitor-native-audio/issues/202
    */
   showNotification?: boolean;
 }
 
+/**
+ * Metadata to display in the notification center, Control Center (iOS), and lock screen
+ * when `showNotification` is enabled in `configure()`.
+ * 
+ * Note: This metadata will only be displayed if `showNotification: true` is set in the
+ * `configure()` method. See {@link ConfigureOptions.showNotification} for important
+ * behavior details about audio mixing on iOS.
+ */
 export interface NotificationMetadata {
   /**
    * The title to display in the notification center
@@ -121,8 +146,13 @@ export interface PreloadOptions {
    */
   isUrl?: boolean;
   /**
-   * Metadata to display in the notification center when audio is playing
-   * Only used when showNotification is enabled in configure()
+   * Metadata to display in the notification center when audio is playing.
+   * Only used when `showNotification: true` is set in `configure()`.
+   * 
+   * See {@link ConfigureOptions.showNotification} for important details about
+   * how this affects audio mixing behavior on iOS.
+   * 
+   * @see NotificationMetadata
    */
   notificationMetadata?: NotificationMetadata;
 }


### PR DESCRIPTION
As highlighted by #202, using the `default`  playback category is required to get `showNotification` working on iOS. This PR implements this change.

Fixes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a notification metadata option to supply title, artist, album and artwork for displayed notifications.

* **Bug Fixes**
  * iOS audio behavior adjusted so enabling notifications will present Now Playing info (may interrupt other app audio).

* **Documentation**
  * Clarified iOS notification behavior and trade-offs in the docs, with guidance on when to enable notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->