### PR TITLE
fix(ios): Prevent deactivation during record-capable mode

### DIFF
--- a/ios/Sources/NativeAudioPlugin/Plugin.swift
+++ b/ios/Sources/NativeAudioPlugin/Plugin.swift
@@ -630,10 +630,19 @@ public class NativeAudio: CAPPlugin, AVAudioPlayerDelegate, CAPBridgedPlugin {
 
             // Only deactivate if no assets are playing AND no other audio is active,
             // and only when we're not in a record-capable mode (e.g. usage with CameraPreview plugin).
+            let isRecordCapableCategory: Bool = {
+                switch session.category {
+                case .record, .playAndRecord, .multiRoute:
+                    return true
+                default:
+                    return false
+                }
+            }()
+
             if !hasPlayingAssets &&
                !session.isOtherAudioPlaying &&
                session.secondaryAudioShouldBeSilencedHint == false &&
-               session.category != .playAndRecord {
+               !isRecordCapableCategory {
                 try self.session.setActive(false, options: .notifyOthersOnDeactivation)
             }
         } catch {


### PR DESCRIPTION
Hello, so i've fixed an issue where the native audio plugin messed with for example the `capgo/camera-preview` plugin when a video was taken. When i created a video with the plugin and then played a sound using the native audio plugin then if i re-recorded a new video the new video would have no sound because of the native audio plugin that did `setActive()`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio session stability by refining when the app deactivates audio. The app now avoids ending audio sessions during active recording-capable scenarios or while other audio is playing, preventing unintended interruptions to recording or playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->