### PR TITLE
fix(ios): fixed issue on unload function not clearing ios notifications and more..

### DIFF
--- a/ios/Sources/NativeAudioPlugin/AudioAsset+Fade.swift
+++ b/ios/Sources/NativeAudioPlugin/AudioAsset+Fade.swift
@@ -34,14 +34,17 @@ extension AudioAsset {
         scheduleLocalFadeOutPauseOnMain(audio: audio, beforePause: beforePause)
     }
 
-    fileprivate func scheduleLocalFadeOutStopOnMain(audio: AVAudioPlayer) {
+    fileprivate func scheduleLocalFadeOutStopOnMain(audio: AVAudioPlayer, beforeStop: ((TimeInterval, TimeInterval) -> Void)?) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.performLocalFadeOutStopOnMain(audio: audio)
+            self.performLocalFadeOutStopOnMain(audio: audio, beforeStop: beforeStop)
         }
     }
 
-    fileprivate func performLocalFadeOutStopOnMain(audio: AVAudioPlayer) {
+    fileprivate func performLocalFadeOutStopOnMain(audio: AVAudioPlayer, beforeStop: ((TimeInterval, TimeInterval) -> Void)?) {
+        let elapsed = audio.currentTime
+        let duration = audio.duration.isFinite ? audio.duration : 0
+        beforeStop?(elapsed, duration)
         audio.stop()
         dispatchComplete()
     }
@@ -71,12 +74,16 @@ extension AudioAsset {
         }
     }
 
+    /// - Parameter beforeStop: Called on the main queue immediately before `stop()` when `toPause` is false,
+    ///   so the plugin can refresh Now Playing (rate 0) at the final elapsed time.
     /// - Parameter beforePause: Called on the main queue immediately before `pause()` when `toPause` is true,
     ///   so the plugin can persist `timeBeforePause` and update Now Playing at the actual stop position.
+    ///   Kept last so call sites can use a trailing closure for fade-out-to-pause.
     func fadeOut(
         audio: AVAudioPlayer,
         fadeOutDuration: TimeInterval,
         toPause: Bool = false,
+        beforeStop: ((TimeInterval, TimeInterval) -> Void)? = nil,
         beforePause: ((TimeInterval, TimeInterval) -> Void)? = nil
     ) {
         cancelFade()
@@ -85,7 +92,7 @@ extension AudioAsset {
             if toPause {
                 scheduleLocalFadeOutPauseOnMain(audio: audio, beforePause: beforePause)
             } else {
-                scheduleLocalFadeOutStopOnMain(audio: audio)
+                scheduleLocalFadeOutStopOnMain(audio: audio, beforeStop: beforeStop)
             }
             return
         }
@@ -108,7 +115,7 @@ extension AudioAsset {
                 if toPause {
                     self.performLocalFadeOutPauseOnMain(audio: audio, beforePause: beforePause)
                 } else {
-                    self.performLocalFadeOutStopOnMain(audio: audio)
+                    self.performLocalFadeOutStopOnMain(audio: audio, beforeStop: beforeStop)
                 }
             }
         }

--- a/ios/Sources/NativeAudioPlugin/AudioAsset.swift
+++ b/ios/Sources/NativeAudioPlugin/AudioAsset.swift
@@ -261,10 +261,10 @@ public class AudioAsset: NSObject, AVAudioPlayerDelegate {
             if player.isPlaying {
                 if toPause {
                     if player.volume > 0 {
-                        fadeOut(audio: player, fadeOutDuration: fadeOutDuration, toPause: true) { [weak self] elapsed, duration in
+                        fadeOut(audio: player, fadeOutDuration: fadeOutDuration, toPause: true, beforePause: { [weak self] elapsed, duration in
                             guard let self, let owner = self.owner else { return }
                             owner.recordPausePositionAfterFade(assetId: self.assetId, elapsedTime: elapsed, duration: duration)
-                        }
+                        })
                     } else {
                         cancelFade()
                         schedulePauseWithPositionRecording(audio: player) { [weak self] elapsed, duration in
@@ -273,9 +273,15 @@ public class AudioAsset: NSObject, AVAudioPlayerDelegate {
                         }
                     }
                 } else if player.volume > 0 {
-                    fadeOut(audio: player, fadeOutDuration: fadeOutDuration, toPause: false)
+                    fadeOut(audio: player, fadeOutDuration: fadeOutDuration, toPause: false, beforeStop: { [weak self] elapsed, duration in
+                        guard let self, let owner = self.owner else { return }
+                        owner.recordStoppedPlaybackStateAfterFade(assetId: self.assetId, elapsedTime: elapsed, duration: duration)
+                    })
                 } else {
+                    let elapsed = player.currentTime
+                    let duration = player.duration.isFinite ? player.duration : 0
                     stop()
+                    owner?.recordStoppedPlaybackStateAfterFade(assetId: assetId, elapsedTime: elapsed, duration: duration)
                 }
             } else if !toPause {
                 stop()

--- a/ios/Sources/NativeAudioPlugin/Plugin.swift
+++ b/ios/Sources/NativeAudioPlugin/Plugin.swift
@@ -266,8 +266,20 @@ public class NativeAudio: CAPPlugin, AVAudioPlayerDelegate, CAPBridgedPlugin {
                     return
                 }
 
+                // Sample before `stop()` — `AudioAsset.stop()` resets every channel's `currentTime` to 0.
+                let elapsedTime = asset.getCurrentTime()
+                let duration = asset.getDuration()
                 asset.stop()
-                self.currentlyPlayingAssetId = nil
+                // Keep `currentlyPlayingAssetId` and Now Playing metadata so the lock screen card
+                // stays until `unload()` (or natural completion / another `play()` replaces it).
+                if self.showNotification,
+                   self.currentlyPlayingAssetId == assetId {
+                    self.updatePlaybackState(
+                        isPlaying: false,
+                        elapsedTime: elapsedTime,
+                        duration: duration
+                    )
+                }
             }
             return .success
         }
@@ -974,7 +986,7 @@ public class NativeAudio: CAPPlugin, AVAudioPlayerDelegate, CAPBridgedPlugin {
 
     /// Stops playback of the audio asset identified by `assetId` from the plugin call and performs related cleanup.
     ///
-    /// The `assetId` is read from the call using `Constant.AssetIdKey`. If the asset is currently playing it will be stopped; if `showNotification` is enabled the Now Playing info is cleared and `currentlyPlayingAssetId` is reset. If the asset was created by `playOnce`, it is removed from `playOnceAssets` and its notification metadata is removed. The audio session is ended if appropriate. The call is resolved on success or rejected with an error message on failure.
+    /// The `assetId` is read from the call using `Constant.AssetIdKey`. If the asset is currently playing it will be stopped. When `showNotification` is enabled and this asset owns Now Playing, playback state is updated to stopped but the Now Playing card is left in place until `unload()` or natural completion. If the asset was created by `playOnce`, it is removed from `playOnceAssets` and its notification metadata is removed. The audio session is ended if appropriate. The call is resolved on success or rejected with an error message on failure.
     @objc func stop(_ call: CAPPluginCall) {
         let audioId = call.getString(Constant.AssetIdKey) ?? ""
         let fadeOut = call.getBool(Constant.FadeOut) ?? false
@@ -989,11 +1001,32 @@ public class NativeAudio: CAPPlugin, AVAudioPlayerDelegate, CAPBridgedPlugin {
             }
 
             do {
+                // Sample before `stopAudio` — non-fade `AudioAsset.stop()` resets `currentTime` to 0.
+                var preStopNowPlayingElapsed: TimeInterval?
+                var preStopNowPlayingDuration: TimeInterval?
+                if !fadeOut,
+                   self.showNotification,
+                   self.currentlyPlayingAssetId == audioId,
+                   let preStopAsset = self.audioList[audioId] as? AudioAsset {
+                    preStopNowPlayingElapsed = preStopAsset.getCurrentTime()
+                    preStopNowPlayingDuration = preStopAsset.getDuration()
+                }
+
                 try self.stopAudio(audioId: audioId, fadeOut: fadeOut, fadeOutDuration: fadeOutDuration)
 
-                // Reset current track when stopping the asset that was playing (internal state, not just for notifications)
-                if self.currentlyPlayingAssetId == audioId {
-                    self.currentlyPlayingAssetId = nil
+                // Keep `currentlyPlayingAssetId` so lock screen / Control Center stays tied to this asset
+                // until `unload()` clears it; refresh Now Playing to a stopped state (rate 0).
+                // Skip when fading out to stop: `recordStoppedPlaybackStateAfterFade` runs when the fade finishes
+                // (and for zero-volume immediate stop inside `stopWithFade`).
+                if let elapsed = preStopNowPlayingElapsed,
+                   let duration = preStopNowPlayingDuration,
+                   self.showNotification,
+                   self.currentlyPlayingAssetId == audioId {
+                    self.updatePlaybackState(
+                        isPlaying: false,
+                        elapsedTime: elapsed,
+                        duration: duration
+                    )
                 }
 
                 // Clean up playOnce tracking if this was a playOnce asset
@@ -1511,6 +1544,16 @@ public class NativeAudio: CAPPlugin, AVAudioPlayerDelegate, CAPBridgedPlugin {
             var data = self.audioAssetData[assetId] ?? [:]
             data["timeBeforePause"] = elapsedTime
             self.audioAssetData[assetId] = data
+            if self.showNotification && self.currentlyPlayingAssetId == assetId {
+                self.updatePlaybackState(isPlaying: false, elapsedTime: elapsedTime, duration: duration)
+            }
+        }
+    }
+
+    /// Refreshes Now Playing to a stopped state after fade-out-to-stop completes (or zero-volume stop-with-fade).
+    internal func recordStoppedPlaybackStateAfterFade(assetId: String, elapsedTime: TimeInterval, duration: TimeInterval) {
+        audioQueue.async { [weak self] in
+            guard let self else { return }
             if self.showNotification && self.currentlyPlayingAssetId == assetId {
                 self.updatePlaybackState(isPlaying: false, elapsedTime: elapsedTime, duration: duration)
             }


### PR DESCRIPTION
Hello, i had an issue on ios where when i called stop() and then unload() of an audio file it didn't remove the IOS audio notification, so i fixed it. Fixed also other fadeIn/fadeOut things.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lock screen and Now Playing card now remain visible until audio is unloaded or replaced, providing improved playback state visibility.

* **Bug Fixes**
  * Enhanced audio fade-out state tracking and stop behavior for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->