### PR TITLE
[codex] fix Android ExoPlayer asset main-thread calls

### DIFF
--- a/android/src/main/java/ee/forgr/audio/NativeAudio.java
+++ b/android/src/main/java/ee/forgr/audio/NativeAudio.java
@@ -729,8 +729,6 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
             if (audioAssetList.containsKey(audioId)) {
                 AudioAsset asset = audioAssetList.get(audioId);
                 if (asset != null) {
-                    boolean wasPlaying = asset.isPlaying();
-
                     JSObject data = getAudioAssetData(audioId);
                     data.put("volumeBeforePause", asset.getVolume());
                     setAudioAssetData(audioId, data);
@@ -741,9 +739,7 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
                         asset.pause();
                     }
 
-                    if (wasPlaying) {
-                        resumeList.add(asset);
-                    }
+                    resumeList.removeIf((candidate) -> candidate == asset);
 
                     updateTrackedPlaybackState(audioId, PlaybackStateCompat.STATE_PAUSED);
 
@@ -792,7 +788,7 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
 
                     data.remove("volumeBeforePause");
                     setAudioAssetData(audioId, data);
-                    resumeList.add(asset);
+                    resumeList.removeIf((candidate) -> candidate == asset);
                     updateTrackedPlaybackState(audioId, PlaybackStateCompat.STATE_PLAYING);
 
                     // Update notification when resumed

--- a/android/src/main/java/ee/forgr/audio/PlayerThread.java
+++ b/android/src/main/java/ee/forgr/audio/PlayerThread.java
@@ -1,0 +1,62 @@
+package ee.forgr.audio;
+
+import android.os.Handler;
+import android.os.Looper;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+final class PlayerThread {
+
+    private PlayerThread() {}
+
+    static void run(PlayerRunnable runnable) throws Exception {
+        call(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T call(PlayerCallable<T> callable) throws Exception {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            return callable.call();
+        }
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Object[] result = new Object[1];
+        final Exception[] error = new Exception[1];
+
+        new Handler(Looper.getMainLooper()).post(() -> {
+            try {
+                result[0] = callable.call();
+            } catch (Exception e) {
+                error[0] = e;
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        try {
+            if (!latch.await(2, TimeUnit.SECONDS)) {
+                throw new Exception("Timed out waiting for ExoPlayer operation on main thread");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new Exception("Interrupted waiting for ExoPlayer operation on main thread", e);
+        }
+
+        if (error[0] != null) {
+            throw error[0];
+        }
+
+        return (T) result[0];
+    }
+
+    interface PlayerRunnable {
+        void run() throws Exception;
+    }
+
+    interface PlayerCallable<T> {
+        T call() throws Exception;
+    }
+}

--- a/android/src/main/java/ee/forgr/audio/RemoteAudioAsset.java
+++ b/android/src/main/java/ee/forgr/audio/RemoteAudioAsset.java
@@ -233,44 +233,30 @@ public class RemoteAudioAsset extends AudioAsset {
 
     @Override
     public boolean pause() throws Exception {
-        final boolean[] wasPlaying = { false };
-        owner
-            .getActivity()
-            .runOnUiThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        cancelFade();
-                        for (ExoPlayer player : players) {
-                            if (player != null && player.isPlaying()) {
-                                player.pause();
-                                stopCurrentTimeUpdates();
-                                wasPlaying[0] = true;
-                            }
-                        }
-                    }
+        return PlayerThread.call(() -> {
+            boolean wasPlaying = false;
+            cancelFade();
+            for (ExoPlayer player : players) {
+                if (player != null && player.isPlaying()) {
+                    player.pause();
+                    stopCurrentTimeUpdates();
+                    wasPlaying = true;
                 }
-            );
-        return wasPlaying[0];
+            }
+            return wasPlaying;
+        });
     }
 
     @Override
     public void resume() throws Exception {
-        owner
-            .getActivity()
-            .runOnUiThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        for (ExoPlayer player : players) {
-                            if (player != null && !player.isPlaying()) {
-                                player.play();
-                            }
-                        }
-                        startCurrentTimeUpdates();
-                    }
+        PlayerThread.run(() -> {
+            for (ExoPlayer player : players) {
+                if (player != null && !player.isPlaying()) {
+                    player.play();
                 }
-            );
+            }
+            startCurrentTimeUpdates();
+        });
     }
 
     @Override
@@ -390,79 +376,75 @@ public class RemoteAudioAsset extends AudioAsset {
 
     @Override
     public float getVolume() throws Exception {
-        if (players.isEmpty()) {
-            throw new Exception("No ExoPlayer available");
-        }
+        return PlayerThread.call(() -> {
+            if (players.isEmpty()) {
+                throw new Exception("No ExoPlayer available");
+            }
 
-        final ExoPlayer player = players.get(playIndex);
-        return player != null ? player.getVolume() : 0;
+            final ExoPlayer player = players.get(playIndex);
+            return player != null ? player.getVolume() : 0f;
+        });
     }
 
     @Override
     public boolean isPlaying() throws Exception {
-        if (players.isEmpty() || !isPrepared) return false;
+        return PlayerThread.call(() -> {
+            if (players.isEmpty() || !isPrepared) return false;
 
-        ExoPlayer player = players.get(playIndex);
-        return player != null && player.isPlaying();
+            ExoPlayer player = players.get(playIndex);
+            return player != null && player.isPlaying();
+        });
     }
 
     @Override
     public double getDuration() {
-        logger.debug("getDuration called, players empty: " + players.isEmpty() + ", isPrepared: " + isPrepared);
-        if (!players.isEmpty() && isPrepared) {
-            final double[] duration = { 0 };
-            owner
-                .getActivity()
-                .runOnUiThread(
-                    new Runnable() {
-                        @Override
-                        public void run() {
-                            ExoPlayer player = players.get(playIndex);
-                            int state = player.getPlaybackState();
-                            logger.debug("Player state: " + state + " (READY=" + Player.STATE_READY + ")");
-                            if (state == Player.STATE_READY) {
-                                long rawDuration = player.getDuration();
-                                logger.debug("Raw duration: " + rawDuration + ", TIME_UNSET=" + androidx.media3.common.C.TIME_UNSET);
-                                if (rawDuration != androidx.media3.common.C.TIME_UNSET) {
-                                    duration[0] = rawDuration / 1000.0;
-                                    logger.debug("Final duration in seconds: " + duration[0]);
-                                } else {
-                                    logger.debug("Duration is TIME_UNSET");
-                                }
-                            } else {
-                                logger.debug("Player not in READY state");
-                            }
+        try {
+            return PlayerThread.call(() -> {
+                logger.debug("getDuration called, players empty: " + players.isEmpty() + ", isPrepared: " + isPrepared);
+                if (!players.isEmpty() && isPrepared) {
+                    ExoPlayer player = players.get(playIndex);
+                    int state = player.getPlaybackState();
+                    logger.debug("Player state: " + state + " (READY=" + Player.STATE_READY + ")");
+                    if (state == Player.STATE_READY) {
+                        long rawDuration = player.getDuration();
+                        logger.debug("Raw duration: " + rawDuration + ", TIME_UNSET=" + androidx.media3.common.C.TIME_UNSET);
+                        if (rawDuration != androidx.media3.common.C.TIME_UNSET) {
+                            double duration = rawDuration / 1000.0;
+                            logger.debug("Final duration in seconds: " + duration);
+                            return duration;
                         }
+                        logger.debug("Duration is TIME_UNSET");
+                    } else {
+                        logger.debug("Player not in READY state");
                     }
-                );
-            return duration[0];
+                }
+                logger.debug("No players or not prepared for duration");
+                return 0.0;
+            });
+        } catch (Exception e) {
+            logger.error("Error getting duration", e);
+            return 0;
         }
-        logger.debug("No players or not prepared for duration");
-        return 0;
     }
 
     @Override
     public double getCurrentPosition() {
-        if (!players.isEmpty() && isPrepared) {
-            final double[] position = { 0 };
-            owner
-                .getActivity()
-                .runOnUiThread(
-                    new Runnable() {
-                        @Override
-                        public void run() {
-                            ExoPlayer player = players.get(playIndex);
-                            if (player.getPlaybackState() == Player.STATE_READY) {
-                                long rawPosition = player.getCurrentPosition();
-                                logger.debug("Raw position: " + rawPosition);
-                                position[0] = rawPosition / 1000.0;
-                            }
-                        }
+        try {
+            return PlayerThread.call(() -> {
+                if (!players.isEmpty() && isPrepared) {
+                    ExoPlayer player = players.get(playIndex);
+                    if (player.getPlaybackState() == Player.STATE_READY) {
+                        long rawPosition = player.getCurrentPosition();
+                        logger.debug("Raw position: " + rawPosition);
+                        return rawPosition / 1000.0;
                     }
-                );
-            return position[0];
+                }
+                return 0.0;
+            });
+        } catch (Exception e) {
+            logger.error("Error getting current position", e);
+            return 0;
         }
-        return 0;
     }
 
     @Override

--- a/android/src/main/java/ee/forgr/audio/StreamAudioAsset.java
+++ b/android/src/main/java/ee/forgr/audio/StreamAudioAsset.java
@@ -185,28 +185,25 @@ public class StreamAudioAsset extends AudioAsset {
 
     @Override
     public boolean pause() throws Exception {
-        final boolean[] wasPlaying = { false };
-        owner
-            .getActivity()
-            .runOnUiThread(() -> {
-                cancelFade();
-                if (player != null && player.isPlaying()) {
-                    player.setPlayWhenReady(false);
-                    stopCurrentTimeUpdates();
-                    wasPlaying[0] = true;
-                }
-            });
-        return wasPlaying[0];
+        return PlayerThread.call(() -> {
+            cancelFade();
+            if (player != null && player.isPlaying()) {
+                player.setPlayWhenReady(false);
+                stopCurrentTimeUpdates();
+                return true;
+            }
+            return false;
+        });
     }
 
     @Override
     public void resume() throws Exception {
-        owner
-            .getActivity()
-            .runOnUiThread(() -> {
+        PlayerThread.run(() -> {
+            if (player != null) {
                 player.setPlayWhenReady(true);
                 startCurrentTimeUpdates();
-            });
+            }
+        });
     }
 
     @Override
@@ -323,50 +320,50 @@ public class StreamAudioAsset extends AudioAsset {
 
     @Override
     public float getVolume() throws Exception {
-        if (player != null) {
-            return player.getVolume();
-        }
-        return 0;
+        return PlayerThread.call(() -> {
+            if (player != null) {
+                return player.getVolume();
+            }
+            return 0f;
+        });
     }
 
     @Override
     public boolean isPlaying() throws Exception {
-        return player != null && player.isPlaying();
+        return PlayerThread.call(() -> player != null && player.isPlaying());
     }
 
     @Override
     public double getDuration() {
-        if (isPrepared) {
-            final double[] duration = { 0 };
-            owner
-                .getActivity()
-                .runOnUiThread(() -> {
-                    if (player.getPlaybackState() == Player.STATE_READY) {
-                        long rawDuration = player.getDuration();
-                        if (rawDuration != androidx.media3.common.C.TIME_UNSET) {
-                            duration[0] = rawDuration / 1000.0;
-                        }
+        try {
+            return PlayerThread.call(() -> {
+                if (isPrepared && player != null && player.getPlaybackState() == Player.STATE_READY) {
+                    long rawDuration = player.getDuration();
+                    if (rawDuration != androidx.media3.common.C.TIME_UNSET) {
+                        return rawDuration / 1000.0;
                     }
-                });
-            return duration[0];
+                }
+                return 0.0;
+            });
+        } catch (Exception e) {
+            logger.error("Error getting duration", e);
+            return 0;
         }
-        return 0;
     }
 
     @Override
     public double getCurrentPosition() {
-        if (isPrepared) {
-            final double[] position = { 0 };
-            owner
-                .getActivity()
-                .runOnUiThread(() -> {
-                    if (player.getPlaybackState() == Player.STATE_READY) {
-                        position[0] = player.getCurrentPosition() / 1000.0;
-                    }
-                });
-            return position[0];
+        try {
+            return PlayerThread.call(() -> {
+                if (isPrepared && player != null && player.getPlaybackState() == Player.STATE_READY) {
+                    return player.getCurrentPosition() / 1000.0;
+                }
+                return 0.0;
+            });
+        } catch (Exception e) {
+            logger.error("Error getting current position", e);
+            return 0;
         }
-        return 0;
     }
 
     @Override


### PR DESCRIPTION
## What
- Marshal ExoPlayer-backed Android asset operations inside `RemoteAudioAsset` and `StreamAudioAsset`.
- Make `pause`, `resume`, `isPlaying`, `getVolume`, `getDuration`, and `getCurrentPosition` run synchronously on the main looper when called from the Capacitor bridge thread.
- Share the bounded main-looper wait helper through package-private `PlayerThread` instead of adding generic dispatch logic to `NativeAudio` or `AudioAsset`.
- Keep explicit user pause/resume out of the lifecycle/audio-focus auto-resume queue.

## Why
- Remote HTTPS progressive assets use ExoPlayer, and ExoPlayer requires player access on its application/main thread.
- The old remote/stream implementations either touched ExoPlayer off-thread or posted reads/actions asynchronously and returned stale `false`/`0` values.
- Once ExoPlayer-backed `isPlaying()` correctly reports state, explicit user pauses must not be queued for automatic resume.

Fixes #298

## How
- Added a small package-private `PlayerThread` helper using the same bounded wait pattern already used for remote unload cleanup.
- Wrapped remote and HLS stream control/query methods at the asset layer where ExoPlayer is owned.
- Changed explicit `pause` and `resume` paths to remove the asset from `resumeList` instead of enqueueing it.

## Testing
- `bun run fmt`
- `bun run verify:ios`
- `cd android && ./gradlew clean build test --max-workers=1`
- `bun run verify:web`
- `cd android && ./gradlew clean build test -PnativeAudio.hls.include=false --max-workers=1`

## Not Tested
- Manual playback on a physical Android device with a remote HTTPS MP3 stream.