### PR TITLE
fix(ios): serialize dispatchedCompleteMap on audio queue (#310)

### DIFF
--- a/ios/Sources/NativeAudioPlugin/AudioAsset+Fade.swift
+++ b/ios/Sources/NativeAudioPlugin/AudioAsset+Fade.swift
@@ -3,11 +3,14 @@ import AVFoundation
 extension AudioAsset {
 
     func dispatchComplete() {
-        if dispatchedCompleteMap[assetId] == true {
-            return
+        owner?.executeOnAudioQueueAsync { [weak self] in
+            guard let self else { return }
+            if self.dispatchedCompleteMap[self.assetId] == true {
+                return
+            }
+            self.owner?.notifyListeners("complete", data: ["assetId": self.assetId])
+            self.dispatchedCompleteMap[self.assetId] = true
         }
-        owner?.notifyListeners("complete", data: ["assetId": assetId])
-        dispatchedCompleteMap[assetId] = true
     }
 
     func cancelFade() {

--- a/ios/Sources/NativeAudioPlugin/AudioAsset.swift
+++ b/ios/Sources/NativeAudioPlugin/AudioAsset.swift
@@ -384,7 +384,10 @@ public class AudioAsset: NSObject, AVAudioPlayerDelegate {
 
     internal func startCurrentTimeUpdates() {
         stopCurrentTimeUpdates()
-        dispatchedCompleteMap[assetId] = false
+        owner?.executeOnAudioQueueAsync { [weak self] in
+            guard let self else { return }
+            self.dispatchedCompleteMap[self.assetId] = false
+        }
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             let timer = Timer(timeInterval: 0.1, repeats: true) { [weak self] _ in

--- a/ios/Sources/NativeAudioPlugin/Plugin.swift
+++ b/ios/Sources/NativeAudioPlugin/Plugin.swift
@@ -1565,6 +1565,17 @@ public class NativeAudio: CAPPlugin, AVAudioPlayerDelegate, CAPBridgedPlugin {
         }
     }
 
+    /// Async barrier write — serializes shared-state mutations onto the audio queue
+    /// WITHOUT blocking the calling thread. Runs inline when already on the queue
+    /// to preserve ordering.
+    internal func executeOnAudioQueueAsync(_ block: @escaping () -> Void) {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            block()
+        } else {
+            audioQueue.async(flags: .barrier, execute: block)
+        }
+    }
+
     /// Use this for read-only access to shared state — avoids the .barrier write lock
     /// that `executeOnAudioQueue` applies, preventing deadlocks with third-party SDKs.
     internal func readOnAudioQueue<T>(_ block: () -> T) -> T {


### PR DESCRIPTION
## Summary
- Fixes [#310](https://github.com/Cap-go/capacitor-native-audio/issues/310): `dispatchedCompleteMap` was mutated off the audio queue from main-thread fade/complete and `startCurrentTimeUpdates` paths, causing Dictionary CoW corruption crashes.
- Adds `executeOnAudioQueueAsync` (async barrier, inline when already on queue) so shared-state writes are serialized without blocking the main thread.
- Routes `dispatchComplete()` and the `dispatchedCompleteMap` reset in `startCurrentTimeUpdates()` through that helper.

## Test plan
- [ ] `bun run verify:ios` (or full `bun run verify`) passes
- [ ] Fade-out stop on a local asset still emits a single `complete` event
- [ ] Remote asset fade-out / seek-to-start complete still emits `complete`
- [ ] Replay after complete still works (`dispatchedCompleteMap` reset on play)
- [ ] No main-thread hangs when calling play/pause/stop during fade


Made with [Cursor](https://cursor.com)